### PR TITLE
Add python-setuptools to debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: zpm
 Maintainer: Lars Butler (larsbutler) <lars.butler@gmail.com>
 Section: python
 Priority: optional
-Build-Depends: python-all (>= 2.6.6-3), debhelper (>= 7.4.3)
+Build-Depends: python-all (>= 2.6.6-3), debhelper (>= 7.4.3), python-setuptools
 Standards-Version: 3.9.1
 
 Package: zpm


### PR DESCRIPTION
Without this, Launchpad package builds (for example) will fail.
