### PR TITLE
Removed superfluous packaging artifacts

### DIFF
--- a/debian/zpm.install
+++ b/debian/zpm.install
@@ -1,1 +1,0 @@
-zpm /usr/bin


### PR DESCRIPTION
The `zpm` binary should already be installed already per the `rules` file, so this `zpm.install` isn't needed.

I've tested this and confirmed that it works with the package here: https://launchpad.net/~lars-butler/+archive/zerovm-latest
