### PR TITLE
gitignore: ignore htmlcov/ and junit.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ zpm.egg-info
 .coverage
 .tox
 nosetests.xml
+htmlcov/
+junit.xml
 
 # vim
 *.swp


### PR DESCRIPTION
gitignore: ignore htmlcov/ and junit.xml

These test report artifacts should never be in version control.
