### PR TITLE
Fix an shlex encoding issue for Python < 2.7.3

### DIFF
--- a/zpmlib/commands.py
+++ b/zpmlib/commands.py
@@ -120,8 +120,9 @@ def _generate_job_desc(zar, swift_url):
         return value
 
     def translate_args(cmdline):
+        cmdline = cmdline.encode('utf8')
         args = shlex.split(cmdline)
-        return ' '.join(escape(arg) for arg in args)
+        return ' '.join(escape(arg.decode('utf8')) for arg in args)
 
     for zgroup in zar['execution']['groups']:
         jgroup = {'name': zgroup['name']}


### PR DESCRIPTION
Fix an shlex encoding issue for Python < 2.7.3

With Python < 2.7.3, shlex.split does not behave correctly with unicode
input. This change encodes the args passed to shlex.split in utf8, and
then decodes each element of the split.

It is well documented that shlex doesn't support unicode input prior to
Python 2.7.3. See http://docs.python.org/2.7/library/shlex.html.
