### PR TITLE
auth: correct URL used to get auth token

### DIFF
--- a/zpmlib/templates/zebra.js
+++ b/zpmlib/templates/zebra.js
@@ -19,7 +19,7 @@ ZwiftClient.prototype.auth = function (success) {
     var self = this;
     $.ajax({
         'type': 'POST',
-        'url': this._authUrl,
+        'url': this._authUrl + '/tokens',
         'data': JSON.stringify(payload),
         'cache': false,
         'success': function (data) {


### PR DESCRIPTION
I must somehow have been testing using a locally modified version of
the file. Without '/tokens' at the end of the URL, you get this error
back from Keystone:

  {"error":
    {"message": "get_version_v2() got an unexpected keyword argument 'auth'",
     "code": 400,
     "title": "Bad Request"}}
