### PR TITLE
doc: avoid using CommandDocumenter automatically

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,9 @@ class CommandDocumenter(autodoc.FunctionDocumenter):
     def add_directive_header(self, sig):
         pass
 
+    @classmethod
+    def can_document_member(cls, member, membername, isattr, parent):
+        return False
 
 def setup(app):
     app.add_autodocumenter(CommandDocumenter)


### PR DESCRIPTION
Using the :members: option with another auto directive could cause the
CommandDocumentor to be selected. This affected automodule, for
example. The class will now never be selected automatically.
