### PR TITLE
doc: include API in generated docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,0 +1,15 @@
+.. _zpm-core:
+
+ZPM Core Functions
+==================
+
+.. automodule:: zpmlib.zpm
+    :members:
+
+.. _miniswift:
+
+MiniSwift
+=========
+
+.. automodule:: zpmlib.miniswift
+    :members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,13 @@ Contents:
    commands
 
 
+API
+===
+
+.. toctree::
+   api
+
+
 Indices and tables
 ==================
 


### PR DESCRIPTION
This change adds auto-generated documentation for the core modules of ZPM. This is useful especially for anyone who wants to write code based on `zpmlib`.
