### PR TITLE
doc/conf.py: remove missing static files warning

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -146,7 +146,7 @@ html_theme = 'haiku'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Docs were configured to reference a static files directory, which
doesn't exist. Since we don't yet have any static files, I just
commented out this part of the configuration.

Prior to this change, you would see an error like this:

<pre>
$ cd doc && make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.2.2
loading pickled environment... done
building [html]: targets for 4 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] api                                                                                                                                                                             
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] intro                                                                                                                                                                            
writing additional files... genindex py-modindex search
copying static files... WARNING: html_static_path entry u'/home/lars/proj/zpm/doc/_static' does not exist
done
copying extra files... done
dumping search index... done
dumping object inventory... done
build succeeded, 1 warning.

Build finished. The HTML pages are in _build/html.
</pre>
