### PR TITLE
README.md: remove updated usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,6 @@ zpm
 ZeroVM Package Manager
 
 
-Usage
------
-
-    usage: zpm [-h] COMMAND ...
-
-    ZeroVM Package Manager
-
-    optional arguments:
-      -h, --help  show this help message and exit
-
-    subcommands:
-      available subcommands
-
-      COMMAND
-        bundle    Bundle a ZeroVM application
-        new       Create a new ZeroVM application workspace
-
-If no `WORKING_DIR` is specified, the current working directory (`.`) is used
-by default.
-
-
 Packaging
 ---------
 


### PR DESCRIPTION
You can get the latest usage by typing `zpm --help`. Keeping the usage
information in the README will only guarantee that it will get
continuously out of sync.
