### PR TITLE
post_job: take job object instead of low-level JSON str

### DIFF
--- a/zpmlib/commands.py
+++ b/zpmlib/commands.py
@@ -181,6 +181,6 @@ def deploy(args):
         from pprint import pprint
         pprint(job)
         print('executing')
-        client.post_job(json.dumps(job))
+        client.post_job(job)
 
     print('app deployed to\n  %s/%s/' % (client._swift_url, args.target))

--- a/zpmlib/miniswift.py
+++ b/zpmlib/miniswift.py
@@ -109,15 +109,16 @@ class ZwiftClient(SwiftClient):
         """
         Start a ZeroVM job, using a pre-uploaded zar.
 
-        :param str job:
-            JSON string containing the job/servlet configuration. For more
-            info, see:
+        :param object job:
+            Object that will be encoded as JSON sent to Zwift. For
+            more information about the job/servlet configuration, see
             https://github.com/zerovm/zerocloud/blob/icehouse/doc/Servlets.md
         """
         headers = {'X-Auth-Token': self._token,
                    'Accept': 'application/json',
                    'X-Zerovm-Execute': '1.0',
                    'Content-Type': 'application/json'}
-        r = requests.post(self._swift_url, data=job, headers=headers)
+        json_data = json.dumps(job)
+        r = requests.post(self._swift_url, data=json_data, headers=headers)
         print(r)
         print(r.content)


### PR DESCRIPTION
I think our methods should operate on high-level objects when they can.
