### PR TITLE
commands: remove some commented-out code

### DIFF
--- a/zpmlib/commands.py
+++ b/zpmlib/commands.py
@@ -142,10 +142,6 @@ def deploy(args):
     tar = tarfile.open(args.zar)
     zar = json.load(tar.extractfile('zar.json'))
 
-    #from pprint import pprint
-    #print('loaded zar:')
-    #pprint(zar)
-
     client = miniswift.ZwiftClient(args.os_auth_url,
                                    args.os_tenant_name,
                                    args.os_username,


### PR DESCRIPTION
This removes some commented-out code, which appears to have been only
for debugging. This code was also causing pep8 errors with later
versions (v1.5-ish) of pep8. The errors I saw when running `tox -e pep8`
were as follows:

zpmlib/commands.py:145:5: E265 block comment should start with '# '
zpmlib/commands.py:146:5: E265 block comment should start with '# '
zpmlib/commands.py:147:5: E265 block comment should start with '# '

Note: These errors do not appear when using the default `pep8` package on Ubuntu 12.04. This seems to be due to the version difference (0.6.1 vs ~1.5.0). See below.

<pre>
$ pep8 --version
0.6.1
$ pep8 zpmlib
[no output]
</pre>


Using the latest `pep8` binary installed into the tox environment, I see this:

<pre>
$ .tox/pep8/bin/pep8 --version
1.5.0
$ .tox/pep8/bin/pep8 zpmlib
zpmlib/commands.py:145:5: E265 block comment should start with '# '
zpmlib/commands.py:146:5: E265 block comment should start with '# '
zpmlib/commands.py:147:5: E265 block comment should start with '# '
</pre>
