### PR TITLE
tox: run cov report with py27 and py3 configs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27, py3, pep8, pyflakes, full, doc
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
-commands = py.test --doctest-modules zpmlib
+commands = py.test --doctest-modules --cov-report term-missing --cov zpmlib zpmlib
 
 [testenv:py3]
 # This is normally a link to python3.2 or python3.3
@@ -19,9 +19,6 @@ commands = pyflakes zpm setup.py zpmlib
 
 [testenv:full]
 commands = py.test --doctest-modules --cov-report html --junit-xml junit.xml --cov zpmlib zpmlib
-
-[testenv:cover]
-commands = py.test --doctest-modules --cov-report term-missing --cov zpmlib zpmlib
 
 [testenv:doc]
 basepython = python


### PR DESCRIPTION
Instead of running a separate coverage report (using only python2.7,
consequently), this change forces command-line coverage reports to be
run with py27 and py3. This is useful because the coverage numbers can
vary from version to version, given the need for try/except for
importing stdlib stuff. This is also helpful in case we need to use
something like `six`, which could introduce python version specific
branches in logic.

Edit: As a follow-up, it would be cool to run coverage with py27 and py3 for the html report, but this isn't quite so trivial, given the way this is integrated with the CI testing facilities. The CI environment expects a single report. We'll have it give it some thought.
