### PR TITLE
Clarify readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ There are currently two options for installing `zpm`.
 
 ## Packaging
 
+Note: This section is interesting only for project maintainers and packagers.
+This is not required for installing and using `zpm`.
+
 1. Install debian packaging dependencies:
 
     $ sudo apt-get install devscripts debhelper


### PR DESCRIPTION
It is evident to me in https://github.com/zerovm/zpm/issues/70 that our README is misleading and is encouraging users to try to package `zpm` in order to just use the tool. This is bad.

This change adds an `Installation` section with explicit install instructions and adds a warning to the packaging section (to prevent most users from falling down a rabbit hole).
