### PR TITLE
ui: add support for input/output devices

### DIFF
--- a/zpmlib/templates/index.html
+++ b/zpmlib/templates/index.html
@@ -27,6 +27,21 @@
                       {% endfor %}
 
                       clone[0].exec.args += ' ' + args.join(' ');
+
+                      $.each(clone, function (i, group) {
+                          $.each(group.file_list, function (i, file) {
+                              var input = null;
+                              if (file.device == 'input') {
+                                  input = $('#input-' + group.name);
+                              } else if (file.device == 'output') {
+                                  input = $('#output-' + group.name);
+                              }
+                              if (input) {
+                                  file.path = client.swiftPath(input.val());
+                              }
+                          });
+                      });
+
                       client.execute(clone, function (result) {
                           $('#stdout').text(result);
                       });
@@ -45,6 +60,29 @@
       <label for="{{ arg }}">{{ label }}:</label>
       <input id="{{ arg }}" type="text" />
     </p>
+    {% endfor %}
+
+    <h2>Input/Output Paths</h2>
+
+    {% for group in zar.execution.groups %}
+        {% for device in group.devices %}
+            {% if device.name == "input" %}
+                <p>
+                  <label for="input-{{ group.name }}">
+                    {{ group.name | capitalize }} input:
+                  </label>
+                  <input id="input-{{ group.name }}" type="text" />
+                </p>
+            {% endif %}
+            {% if device.name == "output" %}
+                <p>
+                  <label for="output-{{ group.name }}">
+                    {{ group.name | capitalize }} output:
+                  </label>
+                  <input id="output-{{ group.name }}" type="text" />
+                </p>
+            {% endif %}
+        {% endfor %}
     {% endfor %}
 
     <p>

--- a/zpmlib/templates/zebra.js
+++ b/zpmlib/templates/zebra.js
@@ -85,6 +85,15 @@ ZwiftClient.prototype.execute = function (job, success) {
 };
 
 /*
+ * Compute a Swift URL. This is a URL of the form
+ * swift://<user>/<relativePath>.
+ */
+ZwiftClient.prototype.swiftPath = function (relativePath) {
+    var user = this._swiftUrl.slice(this._swiftUrl.lastIndexOf('/') + 1);
+    return 'swift://' + user + '/' + relativePath;
+}
+
+/*
  * Escape command line argument. Command line arguments in a job
  * description should be separated with spaces after being escaped
  * with this function.


### PR DESCRIPTION
When the zar.json file has an input or output device for a group,
there will now be a corresponding input field. The path entered there
is a relative Swift path, meaning that it will be used to construct a
Swift URL of the form

```
swift://<user>/<relative path>
```

That way, the user doesn't have to care about the 'AUTH_f7e9...' part
of the URL. Later, we can replace this with a JavaScript file picker
that lets the user browse the Swift objects.
