### PR TITLE
doc: reorder `zpm deploy` args in docs

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -87,7 +87,7 @@ a ZeroCloud cluster, see :doc:`zerocloud-auth-config`.
 We will deploy it to a ``test`` container under the folder
 ``hello``::
 
-   $ zpm deploy hello.zapp test/hello
+   $ zpm deploy test/hello hello.zapp
    deploying hello.zapp
    found token: MIIGjwYJKoZIhvcNAQcC...
    found Swift: http://localhost:8080/v1/account
@@ -96,7 +96,7 @@ We will deploy it to a ``test`` container under the folder
 
 For testing, you can execute the job after it has been deployed::
 
-   $ zpm deploy hello.zapp test/hello --execute
+   $ zpm deploy test/hello hello.zapp --execute
    deploying hello.zapp
    found token: MIIGjwYJKoZIhvcNAQcC...
    found Swift: http://localhost:8080/v1/account

--- a/doc/zerocloud-auth-config.rst
+++ b/doc/zerocloud-auth-config.rst
@@ -19,7 +19,7 @@ so::
     $ zpm deploy --auth http://example.com:5000/auth/v1.0 \
                  --user tenant1:user1 \
                  --key f0ec1500-de68-42bd-8350-f671b50a79bd \
-                 hello.zapp test_container
+                 test_container hello.zapp
 
 Note that with v1, the ``--user`` is a concatentation of the tenant name and
 the username, contrasted with v2 where they are specified separately. (See
@@ -34,7 +34,7 @@ the following environment variables::
 
 Which shortens the ``zpm`` command to this::
 
-    $ zpm deploy hello.zapp test_container
+    $ zpm deploy test_container hello.zapp
 
 For convenience, you can put the above ``export`` statements into a text file
 (called ``zerocloud_v1``, for example) and ``source`` it to automatically set
@@ -52,7 +52,7 @@ so::
                  --os-username user1 \
                  --os-tenant-name tenant1
                  --os-password secret \
-                 hello.zapp test_container
+                 test_container hello.zapp
 
 ``--os-auth-url`` should be the public endpoint defined for
 `Keystone <http://docs.openstack.org/developer/keystone/>`_.
@@ -67,7 +67,7 @@ the following environment variables::
 
 Which shortens the ``zpm`` command to this::
 
-    $ zpm deploy hello.zapp test_container
+    $ zpm deploy test_container hello.zapp
 
 For convenience, you can put the above ``export`` statements into a text file
 (called ``zerocloud_v2``, for example) and ``source`` it to automatically set


### PR DESCRIPTION
The positional argument order changed in
20bb2afede8bb47f7522a99aaf58c3113ce13e6c. This updates the docs to be in
sync with this change.
