### PR TITLE
Fix bundling behavior when files/globs in zapp.yaml do not have a match

### DIFF
--- a/zpmlib/tests/test-bundle.t
+++ b/zpmlib/tests/test-bundle.t
@@ -23,9 +23,9 @@ Test bundling with auto-generated UI:
 
   $ zpm bundle --log-level info
   INFO:adding foo.json
+  INFO:adding zapp.yaml
   WARNING:pattern '*.py' in section 'bundling' matched no files
   INFO:adding /*/foo/a.txt (glob)
-  INFO:adding /*/foo/zapp.yaml (glob)
   INFO:adding index.html
   INFO:adding style.css
   INFO:adding zerocloud.js
@@ -33,8 +33,8 @@ Test bundling with auto-generated UI:
 
   $ tar -tf foo.zapp
   foo.json
-  a.txt
   zapp.yaml
+  a.txt
   index.html
   style.css
   zerocloud.js
@@ -50,16 +50,16 @@ Test bundling with UI
 
   $ zpm bundle --log-level info
   INFO:adding foo.json
+  INFO:adding zapp.yaml
   WARNING:pattern '*.py' in section 'bundling' matched no files
   INFO:adding /*/foo/a.txt (glob)
-  INFO:adding /*/foo/zapp.yaml (glob)
   INFO:adding /*/foo/foo.html (glob)
   INFO:adding /*/foo/myzerocloud.js (glob)
   created foo.zapp
   $ tar -tf foo.zapp
   foo.json
-  a.txt
   zapp.yaml
+  a.txt
   foo.html
   myzerocloud.js
 

--- a/zpmlib/zpm.py
+++ b/zpmlib/zpm.py
@@ -286,6 +286,14 @@ def bundle_project(root):
                     _add_file_to_tar(root, path, tar)
                 file_add_count += len(paths)
 
+    if file_add_count == 0:
+        # None of the files specified in the "bundling" or "ui" sections were
+        # found. Something is wrong.
+        raise zpmlib.ZPMException(
+            "None of the files specified in the 'bundling' or 'ui' sections of"
+            " the zapp.yaml matched anything."
+        )
+
     if not zapp.get('ui'):
         _add_ui(tar, zapp)
 


### PR DESCRIPTION
Fixes https://github.com/zerovm/zpm/issues/119.

This change does two things:
- If a glob in the zapp.yaml "bundling" or "ui" doesn't match any files, log a WARNING
- If none of the globs in "bundling" and "ui" match anything, raise an exception; this means the globs are wrong and there won't be anything useful in the zapp tar file
