### PR TITLE
setup: use setuptools over distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,17 @@
 ZeroVM Package Manager
 """
 
-from distutils.core import setup
+kwargs = {}
+
+try:
+    from setuptools import setup
+    kwargs['install_requires'] = ['requests', 'jinja2<2.7', 'pyyaml',
+                                  'python-swiftclient>=2.1.0']
+except ImportError:
+    import sys
+    sys.stderr.write('warning: setuptools not found, you must '
+                     'manually install dependencies!\n')
+    from distutils.core import setup
 
 import zpmlib
 
@@ -33,8 +43,6 @@ setup(
     package_data={'zpmlib': ['templates/*.html', 'templates/*.css',
                              'templates/*.js', 'templates/*.yaml']},
     provides=['zpm (%s)' % zpmlib.__version__],
-    install_requires=['requests', 'jinja2<2.7', 'pyyaml',
-                      'python-swiftclient>=2.1.0'],
     license='Apache 2.0',
     keywords='zpm zerovm zvm',
     classifiers=(
@@ -52,4 +60,5 @@ setup(
         'Topic :: Software Development :: Build Tools',
     ),
     scripts=['zpm'],
+    **kwargs
 )


### PR DESCRIPTION
Distutils is the stdlib packaging tool. However, setuptools is the
preferred tool for projects that define dependencies:

  https://python-packaging-user-guide.readthedocs.org/en/latest/current.html

Setuptools is a dependency of virtualenv and pip, so most developers
will have it installed.

Using setuptools means that the dependencies will be automatically
installed when running 'python setup.py install'.

This is important for the Read The Docs build since it installs the
project like that instead of using pip. So the documentation build was
broken since the autodoc Sphinx directive fails when our dependencies
are missing.

If setuptools is not present, a warning is printed and the
installation/packaging can continue.
