### PR TITLE
setup: remove version from swiftclient dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ kwargs = {}
 try:
     from setuptools import setup
     kwargs['install_requires'] = ['requests', 'jinja2<2.7', 'pyyaml',
-                                  'python-swiftclient>=2.1.0']
+                                  'python-swiftclient']
 except ImportError:
     import sys
     sys.stderr.write('warning: setuptools not found, you must '


### PR DESCRIPTION
As far as we know, there's no particular reason to pin zpm to depend on
python-swiftclient>=2.1.0. Any version should suit our purposes.
