### PR TITLE
debian/changelog: update for the 0.2 release pkg

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+zpm (0.2-1) precise; urgency=low
+
+  * Version 0.2 release
+
+ -- Lars Butler (larsbutler) <lars.butler@gmail.com>  Sat, 19 Jul 2014 21:22:40 +0000
+
 zpm (0.1-1) precise; urgency=low
 
   * Initial release


### PR DESCRIPTION
Fixes https://github.com/zerovm/zpm/issues/158.

This is meant for packaging the 0.2 tag
(81505fade42134e249cfe410125097820cc8e8b5).

Package released to https://launchpad.net/~zerovm-ci/+archive/ubuntu/zerovm-stable.

There will be a forthcoming patch to v0.2 to add the pkg dep for python-swiftclient, and that package will include all of the latest zpm code.
