### PR TITLE
Debian package for 0.2.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+zpm (0.2.1-1) precise; urgency=low
+
+  * Add python-swiftclient to package install dependencies
+  * Deploy: show full URL to the deployed index.html
+  * Deploy: set correct content type for zapp files
+  * Deploy: better management of containers (automatically create containers
+    if not existing, don't allow deployment to a non-empty container)
+  * setup.py: use setuptools over distutils
+  * setup.py: remove version from swiftclient dep
+
+ -- Lars Butler (larsbutler) <lars.butler@gmail.com>  Sat, 19 Jul 2014 21:38:31 +0000
+
 zpm (0.2-1) precise; urgency=low
 
   * Version 0.2 release

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.1
 
 Package: zpm
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}
+Depends: ${misc:Depends}, ${python:Depends}, python-swiftclient
 Description: ZeroVM Package Manager
  Installs command line tools for creating and bundling ZeroVM applications
 


### PR DESCRIPTION
Fixes #157.

Includes the latest bugfixes to the zpm code, as well the addition of the python-swiftclient dependency in the packaging. (python-swiftclient was a dep as far as the python code was concerned, but not in the package; this was a bug.)

This is a derivative of #160; it should land first for a clean diff.

Update: I have published this package to https://launchpad.net/~zerovm-ci/+archive/ubuntu/zerovm-stable/+packages. Please have a look and test it.
