### PR TITLE
Add logging to `execute` command

### DIFF
--- a/zpmlib/commands.py
+++ b/zpmlib/commands.py
@@ -258,6 +258,7 @@ def deploy(args):
 
 
 @command
+@with_logging
 @arg('--container', help='Swift container name (containing the zapp)')
 @arg('zapp', help='Name of the zapp to execute')
 @login_args


### PR DESCRIPTION
This enables the `--log-level/-l` option for `zpm execute`.
