### PR TITLE
Add `zpm auth` command

### DIFF
--- a/zpmlib/commands.py
+++ b/zpmlib/commands.py
@@ -287,3 +287,10 @@ def version(args):
     """Show the version number"""
     parser = set_up_arg_parser()
     parser.parse_args(['--version'])
+
+
+@command
+@login_args
+def auth(args):
+    """Get auth token and storage URL information"""
+    zpm.auth(args)

--- a/zpmlib/tests/test-help.t
+++ b/zpmlib/tests/test-help.t
@@ -14,6 +14,7 @@ Main help text is shown when no command is given:
     available subcommands
   
     COMMAND
+      auth      Get auth token and storage URL information
       bundle    Bundle a ZeroVM application
       deploy    Deploy a ZeroVM application
       execute   Remotely execute a ZeroVM application.
@@ -58,6 +59,7 @@ Test with non-existing command:
     available subcommands
   
     COMMAND
+      auth      Get auth token and storage URL information
       bundle    Bundle a ZeroVM application
       deploy    Deploy a ZeroVM application
       execute   Remotely execute a ZeroVM application.

--- a/zpmlib/zpm.py
+++ b/zpmlib/zpm.py
@@ -648,3 +648,11 @@ def execute(args):
         data_reader = iter(lambda: zapp_file.read(BUFFER_SIZE), b'')
         conn.post_zapp(data_reader, content_length=size)
         zapp_file.close()
+
+
+def auth(args):
+    conn = _get_zerocloud_conn(args)
+    conn.authenticate()
+
+    print('Auth token: %s' % conn.token)
+    print('Storage URL: %s' % conn.url)


### PR DESCRIPTION
Prints auth token and storage URL information to the console.

I'm working on writing some tutorials for developing on ZeroCloud, and this feature will be very useful for getting the auth token (which is needed for `curl` examples).

Fixes https://github.com/zerovm/zpm/issues/183. Unless there is some disagreement about adding this feature. =)
