### PR TITLE
zpm: only deploy ui when ui section in zapp.yaml

### DIFF
--- a/zpmlib/tests/test_zpm.py
+++ b/zpmlib/tests/test_zpm.py
@@ -163,11 +163,7 @@ class TestFindUIUploads:
     Tests for :func:`zpmlib.zpm._find_ui_uploads`.
     """
 
-    def test_without_ui(self):
-        matches = zpm._find_ui_uploads({}, None)
-        assert matches == zpm._DEFAULT_UI_TEMPLATES
-
-    def test_with_ui(self):
+    def test_with_files(self):
         zapp = {'ui': ['x']}
         tar = mock.Mock(getnames=lambda: ['x', 'y'])
         matches = zpm._find_ui_uploads(zapp, tar)

--- a/zpmlib/zpm.py
+++ b/zpmlib/zpm.py
@@ -356,12 +356,9 @@ def _add_file_to_tar(root, path, tar):
 
 
 def _find_ui_uploads(zapp, tar):
-    if 'ui' not in zapp:
-        return _DEFAULT_UI_TEMPLATES
-
     matches = set()
     names = tar.getnames()
-    for pattern in zapp['ui']:
+    for pattern in zapp.get('ui', []):
         matches.update(fnmatch.filter(names, pattern))
     return sorted(matches)
 


### PR DESCRIPTION
If the `ui` section was not present in the zapp.yaml file (default),
`zpm deploy` would try nonetheless to deploy ui files, resulting in a
crash.

This change fixes that.
