### PR TITLE
debian/changelog: release version 0.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+zpm (0.3.0-1) precise; urgency=low
+
+  * Version 0.3 release
+
+ -- Lars Butler (larsbutler) <lars.butler@gmail.com>  Mon, 10 Nov 2014 14:28:12 +0000
+
 zpm (0.2.1-2) precise; urgency=low
 
   * Fix version number in `zpmlib` package (it was 0.2, now 0.2.1). This is the


### PR DESCRIPTION
Released to https://launchpad.net/~zerovm-ci/+archive/ubuntu/zerovm-stable/+packages with tag https://github.com/zerovm/zpm/releases/tag/0.3.
