### PR TITLE
templates: new default for zapp.yaml help->args

### DIFF
--- a/zpmlib/templates/zapp-with-ui.yaml
+++ b/zpmlib/templates/zapp-with-ui.yaml
@@ -36,8 +36,7 @@ help:
 
   # Help for the command line arguments. Each entry is a two-tuple
   # with an option name and an option help text.
-  args:
-  - ["", ""]
+  args: []
 
 # Files to include in your zapp. Your can use glob patterns here, they
 # will be resolved relative to the location of this file.

--- a/zpmlib/templates/zapp.yaml
+++ b/zpmlib/templates/zapp.yaml
@@ -36,8 +36,7 @@ help:
 
   # Help for the command line arguments. Each entry is a two-tuple
   # with an option name and an option help text.
-  args:
-  - ["", ""]
+  args: []
 
 # Files to include in your zapp. Your can use glob patterns here, they
 # will be resolved relative to the location of this file.


### PR DESCRIPTION
The previous default for help->args was a pair of empty strings. For the
most part, this feature is not used and just creates extra
work/annoyance when creating new apps. Every time I create an app, I
need to change the help->args to []. That's the default now.
