### PR TITLE
Clean up output and execution error handling

### DIFF
--- a/zpm
+++ b/zpm
@@ -29,5 +29,5 @@ if __name__ == "__main__":
     try:
         args.func(args)
     except zpmlib.ZPMException as err:
-        print("\nError:\n%s" % err)
+        print("Error:\n%s" % err)
         sys.exit(1)

--- a/zpmlib/tests/test-deploy.t
+++ b/zpmlib/tests/test-deploy.t
@@ -16,7 +16,6 @@ Test bad --auth-version:
 Test deploy with no credentials set:
 
   $ zpm deploy target zapp
-  
   Error:
   Auth version 1.0 requires ST_AUTH, ST_USER, and ST_KEY environment variables
   to be set or overridden with -A, -U, or -K.

--- a/zpmlib/tests/test_zpm.py
+++ b/zpmlib/tests/test_zpm.py
@@ -472,7 +472,8 @@ print("Hello from ZeroVM!")
             url = 'http://127.0.0.1'
             token = 'abc123'
 
-            def post_job(self, job, response_dict=None):
+            def post_job(self, job, response_dict=None,
+                         response_body_buffer=None):
                 response_dict['status'] = 200
                 response_dict['reason'] = 'OK'
                 response_dict['headers'] = {


### PR DESCRIPTION
If a non-200 response is received from ZeroCloud, we display the actual
cause of the error (to help the user).
