### PR TITLE
Allow `env` to specified for groups in zapp.yaml

### DIFF
--- a/zpmlib/tests/test_zpm.py
+++ b/zpmlib/tests/test_zpm.py
@@ -141,6 +141,7 @@ def test__generate_job_desc():
                  ],
                  'name': 'mapper',
                  'connect': ['reducer'],
+                 'env': {'FOO': 'bar', 'BAZ': 5},
                  'path': 'file://python2.7:python'},
                 {'args': 'reducer.py',
                  'devices': [
@@ -168,7 +169,8 @@ def test__generate_job_desc():
          'connect': ['reducer'],
          'name': 'mapper',
          'exec': {'path': 'file://python2.7:python',
-                  'args': 'mapper.py foo\\x5c\\x2c\\x20\\x5cnbar'}},
+                  'args': 'mapper.py foo\\x5c\\x2c\\x20\\x5cnbar',
+                  'env': {'FOO': 'bar', 'BAZ': 5}}},
         {'devices': [
             {'name': 'python2.7'},
             {'name': 'stdout'}],

--- a/zpmlib/zpm.py
+++ b/zpmlib/zpm.py
@@ -160,13 +160,17 @@ def _generate_job_desc(zapp):
         return ' '.join(escape(arg) for arg in args)
 
     for zgroup in zapp['execution']['groups']:
-        # Copy everything, but handle 'path' and 'args' specially:
+        # Copy everything, but handle 'env', 'path', and 'args' specially:
         jgroup = dict(zgroup)
         jgroup['exec'] = {
             'path': zgroup['path'],
             'args': translate_args(zgroup['args']),
         }
         del jgroup['path'], jgroup['args']
+
+        if 'env' in zgroup:
+            jgroup['exec']['env'] = zgroup['env']
+            del jgroup['env']
         job.append(jgroup)
     return job
 


### PR DESCRIPTION
Some special handling is needed, since `env` needs to be packed inside
the `exec` object of the boot/system.map.
